### PR TITLE
A7077A-54 Update supported object defines

### DIFF
--- a/src/abcc_adaptation/abcc_driver_config.h
+++ b/src/abcc_adaptation/abcc_driver_config.h
@@ -69,13 +69,32 @@
 #define ABCC_CFG_REMAP_SUPPORT_ENABLED             1
 
 /*------------------------------------------------------------------------------
+** Anybus objects to support.
+**------------------------------------------------------------------------------
+*/
+#define ANB_FSI_OBJ_ENABLE                         1
+#define DI_OBJ_ENABLE                              0
+
+/*------------------------------------------------------------------------------
 ** Host application objects to support.
 **------------------------------------------------------------------------------
 */
-#define ANB_FSI_OBJ_ENABLE 1
-#define EIP_OBJ_ENABLE 1
-#define PRT_OBJ_ENABLE 1
-#define MOD_OBJ_ENABLE 1
+#define ASM_OBJ_ENABLE                             0
+#define ETN_OBJ_ENABLE                             0
+#define SYNC_OBJ_ENABLE                            0
+
+#define PRT_OBJ_ENABLE                             1
+#define EIP_OBJ_ENABLE                             1
+#define ECT_OBJ_ENABLE                             0
+#define MOD_OBJ_ENABLE                             1
+#define BAC_OBJ_ENABLE                             0
+#define EPL_OBJ_ENABLE                             0
+#define DPV1_OBJ_ENABLE                            0
+#define DEV_OBJ_ENABLE                             0
+#define COP_OBJ_ENABLE                             0
+#define CCL_OBJ_ENABLE                             0
+#define CFN_OBJ_ENABLE                             0
+#define CIET_OBJ_ENABLE                            0
 
 /*------------------------------------------------------------------------------
 ** Command response list


### PR DESCRIPTION
Update define switches in abcc_driver_config.h

This updates the list of define switches in abcc_driver_config.h to reflect recently added objects. The changes introduce a clearer distinction between Anybus and Host Application objects, with network host objects ordered to match their appearance in the web configurator.